### PR TITLE
Add support for multiple chains 

### DIFF
--- a/examples/4_redeem/op_mainnet/main.go
+++ b/examples/4_redeem/op_mainnet/main.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"github.com/LinkdropHQ/linkdrop-go-sdk"
+	"github.com/ethereum/go-ethereum/common"
+	"log"
+	"os"
+)
+
+func main() {
+	sdk, err := linkdrop.Init(
+		"https://p2p.linkdrop.io",
+		os.Getenv("LINKDROP_API_KEY"),
+		linkdrop.WithProductionDefaults(),
+	)
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	link, err := sdk.GetClaimLink(os.Getenv("LINKDROP_LINK"))
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	txHash, err := link.Redeem(common.HexToAddress(os.Getenv("RECEIVER_ADDRESS")))
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	log.Println("Redeem transaction hash:", txHash)
+}

--- a/examples/7_deposit/op_mainnet/main.go
+++ b/examples/7_deposit/op_mainnet/main.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"crypto/rand"
+	"github.com/LinkdropHQ/linkdrop-go-sdk"
+	"github.com/LinkdropHQ/linkdrop-go-sdk/types"
+	"github.com/LinkdropHQ/linkdrop-go-sdk/utils"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"log"
+	"math/big"
+	"os"
+)
+
+func getRandomBytes(length int64) []byte {
+	b := make([]byte, length)
+	_, err := rand.Read(b)
+	if err != nil {
+		log.Fatalf("Failed to generate random bytes: %v", err)
+	}
+	return b
+}
+
+func sendTransaction(chainId *big.Int, to common.Address, value *big.Int, data []byte) (*types.Transaction, error) {
+	client, err := ethclient.Dial(os.Getenv("RPC_URL"))
+	if err != nil {
+		log.Fatalf("Failed to connect to Ethereum client: %v", err)
+	}
+	privateKey, err := crypto.ToECDSA(common.Hex2Bytes(os.Getenv("PRIVATE_KEY")))
+	if err != nil {
+		return nil, err
+	}
+	return utils.SendTransaction(chainId, to, value, data, client, privateKey)
+}
+
+func main() {
+	sdk, err := linkdrop.Init(
+		"https://p2p.linkdrop.io",
+		os.Getenv("LINKDROP_API_KEY"),
+		linkdrop.WithProductionDefaults(),
+	)
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	// ERC20
+	clERC20, err := sdk.ClaimLink(
+		linkdrop.ClaimLinkCreationParams{
+			Token: types.Token{
+				Type:    types.TokenTypeERC20,
+				ChainId: types.ChainIdOptimism,
+				Address: common.HexToAddress("0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85"),
+			},
+			Sender:     common.HexToAddress(os.Getenv("SENDER_ADDRESS")),
+			Amount:     big.NewInt(100000),
+			Expiration: 1773234550,
+		},
+		getRandomBytes,
+	)
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	url, err := clERC20.ClaimUrl()
+	if err != nil {
+		log.Fatalln(err)
+	}
+	log.Println(url) // The link is valid, but can't be claimed since assets are were deposited
+
+	txHash, err := clERC20.Deposit(sendTransaction)
+	if err != nil {
+		log.Fatalln(err)
+	}
+	log.Println("TX Hash: ", txHash)
+}

--- a/types/chain.go
+++ b/types/chain.go
@@ -1,6 +1,8 @@
 package types
 
-import "github.com/ethereum/go-ethereum/common"
+import (
+	"github.com/ethereum/go-ethereum/common"
+)
 
 type ChainConfig struct {
 	ChainId       ChainId
@@ -10,9 +12,17 @@ type ChainConfig struct {
 type ChainId int64
 
 const (
-	ChainIdBase ChainId = 8453
+	ChainIdBase      ChainId = 8453
+	ChainIdPolygon   ChainId = 137
+	ChainIdAvalanche ChainId = 43114
+	ChainIdOptimism  ChainId = 10
+	ChainIdArbitrum  ChainId = 42161
 )
 
 func (cid *ChainId) IsSupported() bool {
-	return *cid == ChainIdBase
+	switch *cid {
+	case ChainIdBase, ChainIdPolygon, ChainIdAvalanche, ChainIdOptimism, ChainIdArbitrum:
+		return true
+	}
+	return false
 }


### PR DESCRIPTION
Add support for multiple chains and create examples for redeem and deposit

Extended ChainId to support Polygon, Avalanche, Optimism, and Arbitrum. Added example scripts for redeeming and depositing assets using the Linkdrop SDK, demonstrating functionalities like claim link creation and transaction handling.