### PR TITLE
Refactor DecodeLink to improve URL parsing logic

### DIFF
--- a/helpers/decode_link.go
+++ b/helpers/decode_link.go
@@ -31,12 +31,15 @@ func defineSig(signatureLength int, signatureHex string) []byte {
 }
 
 func DecodeLink(link string) (*types.Link, error) {
-	queryArgs, err := url.ParseQuery(link)
+	var queryArgs url.Values
+	parsedLink, err := url.Parse(link)
+	if err != nil {
+		return nil, err
+	}
 	if strings.Contains(link, "/#/") {
-		parsedLink, _ := url.Parse(link)
 		queryArgs, err = url.ParseQuery(strings.Split(parsedLink.Fragment, "?")[1])
 	} else {
-		queryArgs, err = url.ParseQuery(link)
+		queryArgs = parsedLink.Query()
 	}
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse query parameters: %w", err)


### PR DESCRIPTION
The function now explicitly parses the input link using `url.Parse` before processing query parameters, ensuring better error handling and clarity. This change improves maintainability and reduces potential parsing issues with malformed URLs.